### PR TITLE
Fix object object output on glb export

### DIFF
--- a/src/app/ui.js
+++ b/src/app/ui.js
@@ -185,6 +185,9 @@ export function setupUI(tree, environment, renderer, scene, camera, initialPrese
         link.download = 'tree.glb';
         link.click();
       },
+      (err) => {
+        console.error(err);
+      },
       { binary: true }
     );
   });


### PR DESCRIPTION
First of all: Thanks for this awesome tool, using it in the current Ludum Dare contest :+1: 

After the recent change from lil-gui to Tweakpane, the GLB export of the generated trees is broken. Instead, the downloaded file only contains the string "[Object object]".

This fixes the export by re-adding the missing error handler function.